### PR TITLE
Replace connection pool `unwrap()` with `try!()`

### DIFF
--- a/src/redis/ddb.rs
+++ b/src/redis/ddb.rs
@@ -14,7 +14,7 @@ impl Handler<ReadOGNDDB> for RedisExecutor {
     type Result = Result<String, Error>;
 
     fn handle(&mut self, _msg: ReadOGNDDB, _ctx: &mut Self::Context) -> Self::Result {
-        let conn = self.pool.get().unwrap();
+        let conn = self.pool.get()?;
         let result: Option<String> = conn.get("ogn-ddb")?;
         Ok(result.unwrap_or_else(|| "{}".to_string()))
     }
@@ -30,7 +30,7 @@ impl Handler<WriteOGNDDB> for RedisExecutor {
     type Result = Result<(), Error>;
 
     fn handle(&mut self, msg: WriteOGNDDB, _ctx: &mut Self::Context) -> Self::Result {
-        let conn = self.pool.get().unwrap();
+        let conn = self.pool.get()?;
         conn.set("ogn-ddb", msg.0)?;
         Ok(())
     }


### PR DESCRIPTION
This will cause the Redis actor threads to no longer panic when there are no connections available in the connection pool anymore. This should remove the need to manually restart the server when the Redis connection throws up.