### PR TITLE
gateway: Cache OGN position record count

### DIFF
--- a/src/api/status.rs
+++ b/src/api/status.rs
@@ -6,39 +6,32 @@ use serde::Serialize;
 use systemstat::{self, Platform};
 
 use crate::gateway;
-use crate::redis;
 
 #[derive(Serialize)]
 struct Status {
     load: Option<(f32, f32, f32)>,
     users: usize,
-    positions: u64,
+    positions: Option<u64>,
 }
 
 pub fn get(
     gateway: web::Data<Addr<gateway::Gateway>>,
-    redis: web::Data<Addr<redis::RedisExecutor>>,
 ) -> impl Future<Item = impl Responder, Error = Error> {
-    Future::join(
-        gateway.send(gateway::RequestStatus).from_err::<Error>(),
-        redis.send(redis::CountOGNPositions).from_err::<Error>(),
-    )
-    .and_then(|(gateway_status, position_count)| {
-        let sys = systemstat::System::new();
+    gateway
+        .send(gateway::RequestStatus)
+        .from_err::<Error>()
+        .and_then(|gateway_status| {
+            let sys = systemstat::System::new();
 
-        position_count
-            .map(|position_count| {
-                let load = sys
-                    .load_average()
-                    .ok()
-                    .map(|load| (load.one, load.five, load.fifteen));
+            let load = sys
+                .load_average()
+                .ok()
+                .map(|load| (load.one, load.five, load.fifteen));
 
-                web::Json(Status {
-                    load,
-                    users: gateway_status.users,
-                    positions: position_count,
-                })
-            })
-            .map_err(|err| err.into())
-    })
+            Ok(web::Json(Status {
+                load,
+                users: gateway_status.users,
+                positions: gateway_status.record_count,
+            }))
+        })
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -5,7 +5,7 @@ use actix::prelude::*;
 use actix_ogn::OGNMessage;
 use chrono::prelude::*;
 use futures::Future;
-use log::{debug, error};
+use log::{debug, error, warn};
 
 use crate::geo::BoundingBox;
 use crate::ogn;
@@ -20,6 +20,7 @@ pub struct Gateway {
     id_subscriptions: HashMap<String, Vec<Addr<WSClient>>>,
     bbox_subscriptions: HashMap<Addr<WSClient>, BoundingBox>,
     redis_buffer: Vec<(String, redis::OGNPosition)>,
+    record_count: Option<u64>,
 }
 
 impl Gateway {
@@ -30,7 +31,27 @@ impl Gateway {
             id_subscriptions: HashMap::new(),
             bbox_subscriptions: HashMap::new(),
             redis_buffer: Vec::new(),
+            record_count: None,
         }
+    }
+
+    fn update_record_count(&self, ctx: &mut Context<Self>) {
+        let fut = self
+            .redis
+            .send(redis::CountOGNPositions)
+            .map_err(|error| {
+                warn!("Could not count OGN position records in redis: {}", error);
+            })
+            .into_actor(self)
+            .and_then(|result, act, _ctx| {
+                if act.record_count.is_none() || result.is_ok() {
+                    act.record_count = result.ok();
+                }
+
+                fut::ok::<(), (), Self>(())
+            });
+
+        ctx.spawn(fut);
     }
 
     fn flush_records(&mut self, ctx: &mut Context<Self>) {
@@ -65,6 +86,12 @@ impl Actor for Gateway {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
+        self.update_record_count(ctx);
+
+        ctx.run_interval(Duration::from_secs(60), |act, ctx| {
+            act.update_record_count(ctx);
+        });
+
         ctx.run_interval(Duration::from_secs(5), |act, ctx| {
             act.flush_records(ctx);
         });
@@ -85,6 +112,7 @@ impl Message for RequestStatus {
 
 pub struct StatusResponse {
     pub users: usize,
+    pub record_count: Option<u64>,
 }
 
 impl Handler<RequestStatus> for Gateway {
@@ -93,6 +121,7 @@ impl Handler<RequestStatus> for Gateway {
     fn handle(&mut self, _msg: RequestStatus, _ctx: &mut Context<Self>) -> Self::Result {
         MessageResult(StatusResponse {
             users: self.ws_clients.len(),
+            record_count: self.record_count,
         })
     }
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -119,7 +119,7 @@ impl Actor for Gateway {
     fn started(&mut self, ctx: &mut Self::Context) {
         self.update_record_count(ctx);
 
-        ctx.run_interval(Duration::from_secs(60), |act, ctx| {
+        ctx.run_interval(Duration::from_secs(30 * 60), |act, ctx| {
             act.update_record_count(ctx);
         });
 
@@ -129,10 +129,10 @@ impl Actor for Gateway {
 
         ctx.run_later(Duration::from_secs(30), |act, ctx| {
             act.drop_outdated_records(ctx);
-        });
 
-        ctx.run_interval(Duration::from_secs(30 * 60), |act, ctx| {
-            act.drop_outdated_records(ctx);
+            ctx.run_interval(Duration::from_secs(30 * 60), |act, ctx| {
+                act.drop_outdated_records(ctx);
+            });
         });
     }
 }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -80,6 +80,10 @@ impl Gateway {
             );
         }
     }
+
+    fn drop_outdated_records(&self) {
+        self.redis.do_send(redis::DropOldOGNPositions);
+    }
 }
 
 impl Actor for Gateway {
@@ -96,10 +100,10 @@ impl Actor for Gateway {
             act.flush_records(ctx);
         });
 
-        self.redis.do_send(redis::DropOldOGNPositions);
+        self.drop_outdated_records();
 
         ctx.run_interval(Duration::from_secs(30 * 60), |act, _ctx| {
-            act.redis.do_send(redis::DropOldOGNPositions);
+            act.drop_outdated_records();
         });
     }
 }


### PR DESCRIPTION
This significantly speeds up the `/api/status` call and takes some of the load from the redis server for the repeated status requests.