### PR TITLE
serde: Use `derive` feature instead of extra dependency declaration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,7 +1343,6 @@ dependencies = [
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.57 (registry+https://github.com/rust-lang/crates.io-index)",
  "systemstat 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ pretty_env_logger = "0.3"
 r2d2_redis = "0.9"
 regex = "1"
 sentry = "0.17.0"
-serde = "1.0.114"
-serde_derive = "1.0.103"
+serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0"
 systemstat = "0.1.5"
 


### PR DESCRIPTION
This way the versions should always match up :)